### PR TITLE
Color names

### DIFF
--- a/make-pdf.rb
+++ b/make-pdf.rb
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
 
-require 'optparse'
-require 'ostruct'
+require "optparse"
+require "ostruct"
 
 # require 'pry'
-require 'prawn'
-require 'prawn/measurement_extensions'
+require "prawn"
+require "prawn/measurement_extensions"
 
-OPEN_SYM = '{'
-CLOSE_SYM = '}'
+OPEN_SYM = "{"
+CLOSE_SYM = "}"
 PAGE_WIDTH = 210 # mm
 PAGE_HEIGHT = 297 # mm
 
@@ -28,22 +28,22 @@ COLORS = OpenStruct.new({
 })
 
 options = OpenStruct.new({
-  base_color: 'default',
-  highlight_color: 'default_highlight',
-  text: 'Say hello {%username}!'
+  base_color: "default",
+  highlight_color: "default_highlight",
+  text: "Say hello {%username}!",
 })
 
 OptionParser.new do |opt|
-  opt.on('-t', '--text TEXT', 'Text to print')               { |o| options[:text] = o }
-  opt.on('-b', '--base-color TEXT', 'Base color')            { |o| options[:base_color] = o }
-  opt.on('-c', '--highlight-color TEXT', 'Highlight color')  { |o| options[:highlight_color] = o }
-  opt.on('-o', '--output-file TEXT', 'Output file name')     { |o| options[:output] = o }
+  opt.on("-t", "--text TEXT", "Text to print") { |o| options[:text] = o }
+  opt.on("-b", "--base-color TEXT", "Base color") { |o| options[:base_color] = o }
+  opt.on("-c", "--highlight-color TEXT", "Highlight color") { |o| options[:highlight_color] = o }
+  opt.on("-o", "--output-file TEXT", "Output file name") { |o| options[:output] = o }
 end.parse!
 
 chars_count = options
   .text
-  .gsub(OPEN_SYM, '')
-  .gsub(CLOSE_SYM, '')
+  .gsub(OPEN_SYM, "")
+  .gsub(CLOSE_SYM, "")
   .size
 avg_area = PAGE_WIDTH * PAGE_HEIGHT / chars_count
 avg_side = Math.sqrt(avg_area)
@@ -68,14 +68,14 @@ def get_hex_color(color)
   end
 end
 
-Prawn::Document.generate(options.output || 'postcard.pdf') do
+Prawn::Document.generate(options.output || "postcard.pdf") do
   curr_color = get_hex_color(options.base_color)
   curr_row = 0
   curr_col = 0
 
   define_grid(columns: n_cols, rows: n_rows, gutter: 0.1)
 
-  options.text.split('').each do |c|
+  options.text.split("").each do |c|
     if c == OPEN_SYM
       curr_color = get_hex_color(options.highlight_color)
       next
@@ -95,8 +95,8 @@ Prawn::Document.generate(options.output || 'postcard.pdf') do
       bounding_box(
         grid_box.top_left,
         width: grid_box.width,
-        height: grid_box.height) do
-          
+        height: grid_box.height,
+      ) do
         text "#{c.ord}",
              color: curr_color,
              size: avg_side * 0.2.mm,

--- a/make-pdf.rb
+++ b/make-pdf.rb
@@ -1,49 +1,49 @@
 #!/usr/bin/env ruby
 
-require "optparse"
-require "ostruct"
+require 'optparse'
+require 'ostruct'
 
 # require 'pry'
-require "prawn"
-require "prawn/measurement_extensions"
+require 'prawn'
+require 'prawn/measurement_extensions'
 
-OPEN_SYM = "{"
-CLOSE_SYM = "}"
+OPEN_SYM = '{'
+CLOSE_SYM = '}'
 PAGE_WIDTH = 210 # mm
 PAGE_HEIGHT = 297 # mm
 
 COLORS = OpenStruct.new({
-  blue: "0000FF",
-  green: "008000",
-  red: "FF0000",
-  gray: "808080",
-  black: "000000",
-  maroon: "800000",
-  yellow: "FFFF00",
-  navy: "000080",
-  purple: "800080",
+  blue: '0000FF',
+  green: '008000',
+  red: 'FF0000',
+  gray: '808080',
+  black: '000000',
+  maroon: '800000',
+  yellow: 'FFFF00',
+  navy: '000080',
+  purple: '800080',
 
-  default: "0D4F8B",
-  default_highlight: "E3170D",
+  default: '0D4F8B',
+  default_highlight: 'E3170D',
 })
 
 options = OpenStruct.new({
-  base_color: "default",
-  highlight_color: "default_highlight",
-  text: "Say hello {%username}!",
+  base_color: 'default',
+  highlight_color: 'default_highlight',
+  text: 'Say hello {%username}!',
 })
 
 OptionParser.new do |opt|
-  opt.on("-t", "--text TEXT", "Text to print") { |o| options[:text] = o }
-  opt.on("-b", "--base-color TEXT", "Base color") { |o| options[:base_color] = o }
-  opt.on("-c", "--highlight-color TEXT", "Highlight color") { |o| options[:highlight_color] = o }
-  opt.on("-o", "--output-file TEXT", "Output file name") { |o| options[:output] = o }
+  opt.on('-t', '--text TEXT', 'Text to print') { |o| options[:text] = o }
+  opt.on('-b', '--base-color TEXT', 'Base color') { |o| options[:base_color] = o }
+  opt.on('-c', '--highlight-color TEXT', 'Highlight color') { |o| options[:highlight_color] = o }
+  opt.on('-o', '--output-file TEXT', 'Output file name') { |o| options[:output] = o }
 end.parse!
 
 chars_count = options
   .text
-  .gsub(OPEN_SYM, "")
-  .gsub(CLOSE_SYM, "")
+  .gsub(OPEN_SYM, '')
+  .gsub(CLOSE_SYM, '')
   .size
 avg_area = PAGE_WIDTH * PAGE_HEIGHT / chars_count
 avg_side = Math.sqrt(avg_area)
@@ -63,19 +63,19 @@ def get_hex_color(color)
     return color
   else
     # Something's not right
-    puts "Invalid color specified."
+    puts 'Invalid color specified.'
     exit
   end
 end
 
-Prawn::Document.generate(options.output || "postcard.pdf") do
+Prawn::Document.generate(options.output || 'postcard.pdf') do
   curr_color = get_hex_color(options.base_color)
   curr_row = 0
   curr_col = 0
 
   define_grid(columns: n_cols, rows: n_rows, gutter: 0.1)
 
-  options.text.split("").each do |c|
+  options.text.split('').each do |c|
     if c == OPEN_SYM
       curr_color = get_hex_color(options.highlight_color)
       next
@@ -97,7 +97,7 @@ Prawn::Document.generate(options.output || "postcard.pdf") do
         width: grid_box.width,
         height: grid_box.height,
       ) do
-        text "#{c.ord}",
+        text '#{c.ord}',
              color: curr_color,
              size: avg_side * 0.2.mm,
              align: :center,

--- a/make-pdf.rb
+++ b/make-pdf.rb
@@ -12,9 +12,24 @@ CLOSE_SYM = '}'
 PAGE_WIDTH = 210 # mm
 PAGE_HEIGHT = 297 # mm
 
+COLORS = OpenStruct.new({
+  blue: "0000FF",
+  green: "008000",
+  red: "FF0000",
+  gray: "808080",
+  black: "000000",
+  maroon: "800000",
+  yellow: "FFFF00",
+  navy: "000080",
+  purple: "800080",
+
+  default: "0D4F8B",
+  default_highlight: "E3170D",
+})
+
 options = OpenStruct.new({
-  base_color: '0D4F8B',
-  highlight_color: 'E3170D',
+  base_color: 'default',
+  highlight_color: 'default_highlight',
   text: 'Say hello {%username}!'
 })
 
@@ -39,8 +54,22 @@ n_cols = (PAGE_WIDTH / avg_side).ceil
 box_w = PAGE_WIDTH.mm / n_cols
 box_h = PAGE_HEIGHT.mm / n_rows
 
+def get_hex_color(color)
+  if COLORS[color] != nil
+    # User specified color name, so return hex
+    return COLORS[color]
+  elsif !color[/\H/] && color.length == 6
+    # User specified hex
+    return color
+  else
+    # Something's not right
+    puts "Invalid color specified."
+    exit
+  end
+end
+
 Prawn::Document.generate(options.output || 'postcard.pdf') do
-  curr_color = options.base_color
+  curr_color = get_hex_color(options.base_color)
   curr_row = 0
   curr_col = 0
 
@@ -48,10 +77,10 @@ Prawn::Document.generate(options.output || 'postcard.pdf') do
 
   options.text.split('').each do |c|
     if c == OPEN_SYM
-      curr_color = options.highlight_color
+      curr_color = get_hex_color(options.highlight_color)
       next
     elsif c == CLOSE_SYM
-      curr_color = options.base_color
+      curr_color = get_hex_color(options.base_color)
       next
     end
 
@@ -67,7 +96,7 @@ Prawn::Document.generate(options.output || 'postcard.pdf') do
         grid_box.top_left,
         width: grid_box.width,
         height: grid_box.height) do
-
+          
         text "#{c.ord}",
              color: curr_color,
              size: avg_side * 0.2.mm,


### PR DESCRIPTION
Allow user to specify a color name instead of hex value--for a handful of common colors.
Display message when specified color not valid.